### PR TITLE
Fix reference to `buffer` of `BufferWriter` (no longer a function)

### DIFF
--- a/source/curl/Highlevel.ooc
+++ b/source/curl/Highlevel.ooc
@@ -157,7 +157,7 @@ HTTPRequest: class {
     }
 
     getString: func -> String {
-        writer as BufferWriter buffer() toString()
+        writer as BufferWriter buffer toString()
     }
 
     /* methods for later (after perform) */


### PR DESCRIPTION
`getString` in `HTTPRequest` was accessing `buffer` in `BufferWriter` via a call to `buffer()`, which did not exist, rather than accessing `buffer`.
